### PR TITLE
WIP - Show a "progress dialog" during translations.

### DIFF
--- a/MassTranslator.Win/MassTranslator.Win.csproj
+++ b/MassTranslator.Win/MassTranslator.Win.csproj
@@ -39,6 +39,7 @@
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Xml" />
@@ -65,6 +66,10 @@
       <DependentUpon>OutWindow.xaml</DependentUpon>
     </Compile>
     <Compile Include="OutWindowViewModel.cs" />
+    <Compile Include="ProgressDialogView.xaml.cs">
+      <DependentUpon>ProgressDialogView.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="ProgressDialogViewModel.cs" />
     <Compile Include="RelayCommand.cs" />
     <Compile Include="SettingBindingExtension.cs" />
     <Compile Include="TranslatorModel.cs" />
@@ -90,6 +95,10 @@
       <SubType>Code</SubType>
     </Compile>
     <Page Include="OutWindow.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="ProgressDialogView.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/MassTranslator.Win/ModelFactory.cs
+++ b/MassTranslator.Win/ModelFactory.cs
@@ -1,4 +1,6 @@
-﻿namespace MassTranslator.Win
+﻿using System.Threading;
+
+namespace MassTranslator.Win
 {
     public class ModelFactory
     {
@@ -27,6 +29,11 @@
         public OutWindowViewModel CreateOutWindowViewModel()
         {
             return new OutWindowViewModel(_model);
+        }
+
+        public ProgressDialogViewModel CreateProgressDialogViewModel(CancellationTokenSource cts, string title, string text)
+        {
+            return new ProgressDialogViewModel(cts, title, text);
         }
     }
 }

--- a/MassTranslator.Win/ProgressDialogView.xaml
+++ b/MassTranslator.Win/ProgressDialogView.xaml
@@ -1,0 +1,16 @@
+﻿<Window x:Class="MassTranslator.Win.ProgressDialogView"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:MassTranslator.Win"
+        mc:Ignorable="d"
+        Title="{Binding Path=Title}" Height="300" Width="300"
+        ResizeMode="NoResize">
+    <Grid>
+        <StackPanel>
+            <Label Content="{Binding Path=Text}"></Label>
+            <Button IsCancel="True">Cancel</Button>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/MassTranslator.Win/ProgressDialogView.xaml.cs
+++ b/MassTranslator.Win/ProgressDialogView.xaml.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Shapes;
+
+namespace MassTranslator.Win
+{
+    /// <summary>
+    /// Interaction logic for ProgressDialog.xaml
+    /// </summary>
+    public partial class ProgressDialogView : Window
+    {
+        public ProgressDialogView(CancellationTokenSource cts, string title, string text)
+        {
+            InitializeComponent();
+            var viewModel = ((App)Application.Current).ModelFactory.CreateProgressDialogViewModel(cts, title, text);
+            this.DataContext = viewModel;
+            this.Closing += viewModel.ViewClosingEvent;
+        }
+    }
+}

--- a/MassTranslator.Win/ProgressDialogViewModel.cs
+++ b/MassTranslator.Win/ProgressDialogViewModel.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Input;
+
+namespace MassTranslator.Win
+{
+    public class ProgressDialogViewModel : ViewModelBase
+    {
+        private CancellationTokenSource cts;
+
+        public ProgressDialogViewModel(CancellationTokenSource cts, string title, string text)
+        {
+            this.cts = cts;
+            this.Title = title;
+            this.Text = text;
+        }
+
+        public string Title { get; private set; }
+
+        public string Text { get; private set; }
+
+        private void Cancel(Object obj)
+        {
+            cts.Cancel();
+        }
+
+        public void ViewClosingEvent(object sender, EventArgs e)
+        {
+            Cancel(null);
+        }
+    }
+}

--- a/MassTranslator.Win/TwoWayTranslatorViewModel.cs
+++ b/MassTranslator.Win/TwoWayTranslatorViewModel.cs
@@ -1,5 +1,8 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
+using System.Windows;
 using System.Windows.Input;
 
 namespace MassTranslator.Win
@@ -29,10 +32,26 @@ namespace MassTranslator.Win
             SelectedLanguageTo = tmpLanguage;
         }
 
-
         private void Translate(object obj)
         {
-            TextTo = _model.Translate(SelectedLanguageFrom.Abbr, SelectedLanguageTo.Abbr, TextFrom);
+            var cts = new CancellationTokenSource();
+
+            // TODO: Consider moving view creation outside the view model.
+            var dialog = new ProgressDialogView(cts, "Translation status", "Translation ongoing...");
+            dialog.Loaded += async (object sender, RoutedEventArgs e) =>
+            {
+                try
+                {
+                    TextTo = await _model.Translate(SelectedLanguageFrom.Abbr, SelectedLanguageTo.Abbr, TextFrom, cts.Token);
+                    dialog.Close();
+                }
+                catch (OperationCanceledException)
+                {
+                    // Operation cancelled, no further action required.
+                }
+            };
+
+            dialog.ShowDialog();
         }
 
         public ICommand TranslateCommand { get; set; }


### PR DESCRIPTION
This is a WIP for #4. While I think the functionality requested is implemented there exists some limitations which I don't have time to look at right now.

Good to know:
- No tests have been performed for the XML translator view. It "should" be prepared for asynchronous translations but no guarantees.
- When a translation is being performed a dialog is shown with a cancel button. The dialog is closed automatically when translation is completed. If dialog is closed, or the cancel button is pressed, the translation is aborted.
  - I opted for a dialog instead of only disabling controls and showing progress to enable the cancel functionality. The dialog does however cause some extra complexity. One option might be to let the "Translate" button act as cancel during translations.
- The dialog view needs some design love if it is going to be used.
- Creation of the view for the dialog is done directly within a view model. This should probably be replaced with a better architecture for creation.